### PR TITLE
Switch Notes to JSON

### DIFF
--- a/sql/create_database.sql
+++ b/sql/create_database.sql
@@ -32,7 +32,7 @@ CREATE TABLE tblNotes (
   note_id INT PRIMARY KEY AUTO_INCREMENT,
   account_id INT NOT NULL,
   title VARCHAR(255) NOT NULL,
-  url VARCHAR(255) NOT NULL,
+  content TEXT NOT NULL,
   FOREIGN KEY (account_id) REFERENCES tblAccount(account_id)
 );
 

--- a/sql/populate_database.sql
+++ b/sql/populate_database.sql
@@ -31,24 +31,14 @@ INSERT INTO tblProtocol (title, content) VALUES
 ('ABC', 'Airway - Check that the casualtys airway is unblocked.\nBreathing - Check that the casualty is breathing.\nCirculation - Check that the casulty has circulation with a capillary pinch test, or by measuring their pulse.\nIf any of these fail, administer CPR immediately'),
 ('CPR', '1. Lean the casultys head back, with their mouth open.\n2. Perform 30 chest compressions at 100 beats per minute, or to the beat of Stayin Alive by the Bee Gees on the casultys solar plexus / end of their sternum.\n3. After 30 compressions, administer 2 breaths to the casulty.\n4.Repeat until emergency services arrive!');
 
-INSERT INTO tblNotes (account_id, url) VALUES
-(1, 'ABCDEFG'),
-(1, 'ABCDEFG'),
-(2, 'ABCDEFG'),
-(2, 'ABCDEFG'),
-(3, 'ABCDEFG'),
-(3, 'ABCDEFG'),
-(4, 'ABCDEFG'),
-(4, 'ABCDEFG'),
-(5, 'ABCDEFG'),
-(5, 'ABCDEFG'),
-(6, 'ABCDEFG'),
-(6, 'ABCDEFG'),
-(7, 'ABCDEFG'),
-(7, 'ABCDEFG'),
-(8, 'ABCDEFG'),
-(8, 'ABCDEFG'),
-(9, 'ABCDEFG'),
-(9, 'ABCDEFG'),
-(10, 'ABCDEFG'),
-(10, 'ABCDEFG');
+INSERT INTO tblNotes (account_id, title, content) VALUES
+(1, 'Lecture Notes', 'Today we covered respiratory physiology. Here are the key points:\n\n* Oxygen and carbon dioxide exchange occurs in the alveoli of the lungs.\n* The respiratory system is controlled by the medulla oblongata in the brainstem.\n* The diaphragm and intercostal muscles are responsible for breathing.\n\n---\n\n'),
+(2, 'Study Group', 'Meeting with classmates to review material for upcoming exam. We covered:\n\n* Endocrine system\n* Renal system\n* Hematology\n\nWe created flashcards to help us memorize key concepts.\n\n---\n\n'),
+(3, 'Patient Rounds', 'Observed a patient with COPD this morning. Here are my observations:\n\n* The patient had difficulty breathing and used a nebulizer to help open their airways.\n* The patient was on supplemental oxygen via nasal cannula.\n* We discussed the importance of smoking cessation and medication adherence with the patient.\n\n---\n\n'),
+(4, 'Medical Ethics', 'Discussed ethical dilemmas in medicine during seminar. We covered:\n\n* Patient autonomy\n* Informed consent\n* End-of-life care\n\nWe debated various scenarios and discussed how to handle ethical dilemmas in practice.\n\n---\n\n'),
+(5, 'Clinical Rotation', 'Started my rotation in the cardiology ward. Here are some interesting cases:\n\n* Patient with atrial fibrillation and heart failure\n* Patient with myocardial infarction\n* Patient with hypertrophic cardiomyopathy\n\nI observed procedures such as angiograms and echocardiograms.\n\n---\n\n'),
+(6, 'Research Paper', 'Working on a paper about the effects of exercise on heart health. My research has shown that:\n\n* Regular exercise can reduce the risk of heart disease.\n* Exercise can improve cardiovascular function and lower blood pressure.\n* Exercise can also have psychological benefits, such as reducing stress and anxiety.\n\n---\n\n'),
+(7, 'Grand Rounds', 'Attended a presentation on rare diseases. Some of the diseases discussed were:\n\n* Marfan syndrome\n* Huntingtons disease\n* Alpha-1 antitrypsin deficiency\n\nWe also discussed the challenges of diagnosing and treating rare diseases.\n\n---\n\n'),
+(8, 'Anatomy Lab', 'Dissected a cadaver to study the musculoskeletal system. We identified and studied the following structures:\n\n* Bones: femur, tibia, fibula, humerus, radius, ulna\n* Joints: hip, knee, ankle, shoulder, elbow, wrist\n* Muscles: quadriceps, hamstrings, biceps, triceps, deltoids\n\n---\n\n'),
+(9, 'Emergency Room', 'Worked in the ER and saw several cases of trauma. Some of the cases were:\n\n* Motor vehicle accident\n* Gunshot wound\n* Fall from height\n\nI assisted with procedures such as intubation, chest tube placement, and wound care.\n\n---\n\n')
+(10, 'Surgery Rotation', 'Started my rotation in the surgical ward. Observed several procedures, including:\n\n* Appendectomy\n* Cholecystectomy\n* Hysterectomy\n\nI also learned about postoperative care and wound management.\n\n---\n\n');

--- a/src/db.rs
+++ b/src/db.rs
@@ -32,6 +32,6 @@ pub struct Protocol {
 pub struct Note {
     pub note_id: i32,
     pub account_id: i32,
-    pub url: String,
+    pub content: String,
     pub title: String
 }

--- a/src/endpoints/errors.rs
+++ b/src/endpoints/errors.rs
@@ -9,7 +9,7 @@ pub enum ApiErrors {
     #[response(status = 404)]
     NotFound(String),
     #[response(status = 400)]
-    BadRequest(String),
+    _BadRequest(String),
     #[response(status = 500)]
     InternalError(String)
 }

--- a/src/endpoints/notes.rs
+++ b/src/endpoints/notes.rs
@@ -7,7 +7,6 @@ mod tests;
 mod note_files;
  
 use rocket::serde::json::Json;
-use rocket::fs::TempFile;
 use rocket_db_pools::{
     Connection,
     sqlx

--- a/src/endpoints/notes/note_files.rs
+++ b/src/endpoints/notes/note_files.rs
@@ -3,18 +3,32 @@ use serde::{Serialize, Deserialize};
 use crate::db;
 
 #[derive(Serialize)]
-pub struct NoteFile {
+pub struct NoteResponse {
     pub note_id: i32,
-    pub note_url: String,
     pub note_title: String,
+    pub note_content: String,
 }
 
-impl From<&db::Note> for NoteFile {
+#[derive(Deserialize)]
+pub struct NewNote {
+    pub account_id: i32,
+    pub note_title: String,
+    pub note_content: String
+}
+
+#[derive(Deserialize)]
+pub struct UpdateNote {
+    pub note_id: i32,
+    pub note_title: String,
+    pub note_content: String,
+}
+
+impl From<&db::Note> for NoteResponse {
     fn from(value: &db::Note) -> Self {
-        NoteFile {
+        NoteResponse {
             note_id: value.note_id,
             note_title: value.title.clone(),
-            note_url: value.url.clone()
+            note_content: value.content.clone()
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,8 +86,7 @@ fn rocket() -> _ {
             endpoints::notes::fetch_notes,
             endpoints::notes::add_note,
             endpoints::notes::remove_note,
-            endpoints::notes::update_note_content,
-            endpoints::notes::update_note_title,
+            endpoints::notes::update_note,
         ])
         .mount("/static", FileServer::from(static_dir))
         .attach(db::SPS::init())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,28 +6,8 @@ mod db;
 extern crate rocket;
 extern crate lazy_static;
 
-use rocket::fs::FileServer;
 use simple_logger::SimpleLogger;
-use systemd_journal_logger::{
-    connected_to_journal,
-    init_with_extra_fields
-};
-use config::Config;
-use lazy_static::lazy_static;
-use tokio::sync::RwLock;
 use rocket_db_pools::Database;
-use futures::executor::block_on;
-
-// Add all our settings to a global variable
-// RwLock - https://docs.rs/tokio/1.26.0/tokio/sync/struct.RwLock.html
-// lazy_static - https://docs.rs/lazy_static/latest/lazy_static/
-// config - https://docs.rs/config/0.13.3/config/
-lazy_static! {
-    static ref SETTINGS: RwLock<Config> = RwLock::new(
-        Config::builder()
-            .add_source(config::File::with_name("./config.toml")).build().unwrap()
-    );
-}
 
 #[cfg(test)]
 pub mod tests {
@@ -46,32 +26,10 @@ pub mod tests {
 #[launch]
 fn rocket() -> _ {
 
-    // If the systemd service is setup, write to the journal
-    if connected_to_journal() {
-        init_with_extra_fields(vec![("CARGO_VERSION", env!("CARGO_PKG_VERSION"))]).unwrap();
-    } else {
-        // Else just use stdout to write logs
-        match SimpleLogger::new().init() {
-            Err(e) => println!("Logger Error: {e}"),
-            _ => ()
-        }
-    }
-
-    let settings = block_on(SETTINGS.read());
-    let static_dir = match settings.get::<String>("static_file_directory") {
-        Ok(val) => val,
-        Err(e) => { 
-            log::error!("Cannot read static file directory config option {}", e);
-            panic!(); // Panic because not actually sure what I can put here because of rocket
-        }
-    };
-
-    match std::fs::create_dir_all(&static_dir) {
-        Ok(_) => log::info!("Successfully created static file directory"),
-        Err(e) => {
-            log::error!("Cannot create static file directory {}", e);
-            panic!(); // Not sure how to exit program with rocket. Needs to be fixed later
-        }
+    // Use simple logger for logging purposes
+    match SimpleLogger::new().init() {
+        Err(e) => println!("Logger Error: {e}"),
+        _ => ()
     }
 
     // Rocket HTTP server creation routine
@@ -88,6 +46,5 @@ fn rocket() -> _ {
             endpoints::notes::remove_note,
             endpoints::notes::update_note,
         ])
-        .mount("/static", FileServer::from(static_dir))
         .attach(db::SPS::init())
 }


### PR DESCRIPTION
The tests for static files introduces too much complexity.

Switching to json helps reduce this difficulty, and keeps the code slightly more maintainable within the database even if it does make it more difficult to scale 